### PR TITLE
 Add register of ball's last kick

### DIFF
--- a/lib/rubygoal/ball.rb
+++ b/lib/rubygoal/ball.rb
@@ -6,7 +6,7 @@ module Rubygoal
   class Ball
     include Moveable
 
-    attr_accessor :last_kick
+    attr_reader :last_kick
 
     def initialize
       super
@@ -17,11 +17,12 @@ module Rubygoal
       Field.goal?(position)
     end
 
-    def move(direction, speed)
+    def move(direction, speed, kicker)
       self.velocity = Velocity.new(
         Util.offset_x(direction, speed),
         Util.offset_y(direction, speed)
       )
+      @last_kick = kicker
     end
 
     def reinitialize_position

--- a/lib/rubygoal/ball.rb
+++ b/lib/rubygoal/ball.rb
@@ -6,6 +6,8 @@ module Rubygoal
   class Ball
     include Moveable
 
+    attr_accessor :last_kick
+
     def initialize
       super
       reinitialize_position
@@ -24,6 +26,7 @@ module Rubygoal
 
     def reinitialize_position
       self.position = Field.center_position
+      @last_kick = nil
     end
 
     def update(elapsed_time)
@@ -36,12 +39,8 @@ module Rubygoal
     private
 
     def prevent_out_of_bounds
-      if Field.out_of_bounds_width?(position)
-        velocity.x *= -1
-      end
-      if Field.out_of_bounds_height?(position)
-        velocity.y *= -1
-      end
+      velocity.x *= -1 if Field.out_of_bounds_width?(position)
+      velocity.y *= -1 if Field.out_of_bounds_height?(position)
     end
 
     def decelerate(elapsed_time)
@@ -54,7 +53,7 @@ module Rubygoal
       custom_frame_rate = 1 / 60.0
       time_coef = elapsed_time / custom_frame_rate
 
-      Rubygoal.configuration.deceleration_coef ** time_coef
+      Rubygoal.configuration.deceleration_coef**time_coef
     end
   end
 end

--- a/lib/rubygoal/configuration.rb
+++ b/lib/rubygoal/configuration.rb
@@ -7,7 +7,8 @@ module Rubygoal
                   :deceleration_coef, :initial_player_positions, :game_time,
                   :average_lower_error, :average_upper_error, :average_speed,
                   :fast_lower_error, :fast_upper_error, :fast_speed,
-                  :captain_error, :captain_speed, :debug_output, :record_game
+                  :captain_error, :captain_speed, :debug_output, :record_game,
+                  :record_last_kick
   end
 
   class << self
@@ -45,5 +46,6 @@ module Rubygoal
     config.game_time             = 120
     config.debug_output          = true
     config.record_game           = false
+    config.record_last_kick      = false
   end
 end

--- a/lib/rubygoal/player.rb
+++ b/lib/rubygoal/player.rb
@@ -20,7 +20,6 @@ module Rubygoal
       @time_to_kick_again = 0
       @side = side
       @player_movement = PlayerMovement.new(game, self)
-      @game = game
       @name = name
     end
 

--- a/lib/rubygoal/player.rb
+++ b/lib/rubygoal/player.rb
@@ -20,6 +20,7 @@ module Rubygoal
       @time_to_kick_again = 0
       @side = side
       @player_movement = PlayerMovement.new(game, self)
+      @game = game
     end
 
     def can_kick?(ball)
@@ -31,6 +32,7 @@ module Rubygoal
       strength = random_strength
 
       ball.move(direction, strength)
+      ball.last_kick = player_info
       reset_waiting_to_kick!
     end
 
@@ -82,6 +84,18 @@ module Rubygoal
       angle_error_range = -max_angle_error..max_angle_error
 
       direction += Random.rand(angle_error_range)
+    end
+
+    def player_info
+      team = side == :home ? @game.team_home : @game.team_away
+      player_name = nil
+      team.players.each do |name, player|
+        if player == self
+          player_name = name
+          break
+        end
+      end
+      { name: player_name, side: side }
     end
   end
 end

--- a/lib/rubygoal/player.rb
+++ b/lib/rubygoal/player.rb
@@ -11,16 +11,17 @@ module Rubygoal
 
     include Moveable
 
-    attr_reader :side, :type
+    attr_reader :side, :type, :name
     attr_accessor :coach_defined_position
 
-    def initialize(game, side)
+    def initialize(game, side, name)
       super()
 
       @time_to_kick_again = 0
       @side = side
       @player_movement = PlayerMovement.new(game, self)
       @game = game
+      @name = name
     end
 
     def can_kick?(ball)
@@ -31,8 +32,7 @@ module Rubygoal
       direction = random_direction(target)
       strength = random_strength
 
-      ball.move(direction, strength)
-      ball.last_kick = player_info
+      ball.move(direction, strength, name: name, side: side)
       reset_waiting_to_kick!
     end
 
@@ -84,18 +84,6 @@ module Rubygoal
       angle_error_range = -max_angle_error..max_angle_error
 
       direction += Random.rand(angle_error_range)
-    end
-
-    def player_info
-      team = side == :home ? @game.team_home : @game.team_away
-      player_name = nil
-      team.players.each do |name, player|
-        if player == self
-          player_name = name
-          break
-        end
-      end
-      { name: player_name, side: side }
     end
   end
 end

--- a/lib/rubygoal/recorder.rb
+++ b/lib/rubygoal/recorder.rb
@@ -35,7 +35,8 @@ module Rubygoal
           @game.ball.position.y.round(0)
         ],
         home: team_info(@game.team_home),
-        away: team_info(@game.team_away)
+        away: team_info(@game.team_away),
+        last_kick: last_kick_info
       }
     end
 
@@ -47,6 +48,12 @@ module Rubygoal
           player.rotation.round(0),
           player.type[0]
         ]
+      end
+    end
+
+    def last_kick_info
+      if @game.ball.last_kick
+        [@game.ball.last_kick[:name], @game.ball.last_kick[:side]]
       end
     end
   end

--- a/lib/rubygoal/recorder.rb
+++ b/lib/rubygoal/recorder.rb
@@ -27,7 +27,7 @@ module Rubygoal
     attr_reader :game, :frames
 
     def frame_info
-      {
+      frame = {
         time: @game.time.round(0),
         score: [@game.score_home, @game.score_away],
         ball: [
@@ -35,9 +35,11 @@ module Rubygoal
           @game.ball.position.y.round(0)
         ],
         home: team_info(@game.team_home),
-        away: team_info(@game.team_away),
-        last_kick: last_kick_info
+        away: team_info(@game.team_away)
       }
+      last_kick_info(frame) if Rubygoal.configuration.record_last_kick
+
+      frame
     end
 
     def team_info(team)
@@ -51,9 +53,12 @@ module Rubygoal
       end
     end
 
-    def last_kick_info
+    def last_kick_info(frame)
       if @game.ball.last_kick
-        [@game.ball.last_kick[:name], @game.ball.last_kick[:side]]
+        frame[:last_kick] = [
+          @game.ball.last_kick[:name],
+          @game.ball.last_kick[:side]
+        ]
       end
     end
   end

--- a/lib/rubygoal/team.rb
+++ b/lib/rubygoal/team.rb
@@ -101,21 +101,21 @@ module Rubygoal
     end
 
     def initialize_players
-      @players = { goalkeeper: GoalKeeperPlayer.new(game, side) }
+      @players = { goalkeeper: GoalKeeperPlayer.new(game, side, :goalkeeper) }
 
       unless @coach.valid?
         puts @coach.errors
         raise "Invalid team definition: #{@coach.name}"
       end
 
-      @players[@coach.captain_player.name] = CaptainPlayer.new(game, side)
+      @players[@coach.captain_player.name] = CaptainPlayer.new(game, side, @coach.captain_player.name)
 
       @coach.players_by_type(:fast).each do |player_def|
-        @players[player_def.name] = FastPlayer.new(game, side)
+        @players[player_def.name] = FastPlayer.new(game, side, player_def.name)
       end
 
       @coach.players_by_type(:average).each do |player_def|
-        @players[player_def.name] = AveragePlayer.new(game, side)
+        @players[player_def.name] = AveragePlayer.new(game, side, player_def.name)
       end
 
       initialize_player_positions
@@ -140,12 +140,11 @@ module Rubygoal
       nearest_teammate = nil
 
       (players.values - [player]).each do |teammate|
-        if teammate_is_on_front?(player, teammate)
-          dist = player.distance(teammate.position)
-          if min_dist > dist
-            nearest_teammate = teammate
-            min_dist = dist
-          end
+        next unless teammate_is_on_front?(player, teammate)
+        dist = player.distance(teammate.position)
+        if min_dist > dist
+          nearest_teammate = teammate
+          min_dist = dist
         end
       end
 

--- a/test/player_test.rb
+++ b/test/player_test.rb
@@ -118,6 +118,20 @@ module Rubygoal
       assert_in_delta 20, velocity_strength, 1
     end
 
+    def test_kick_registered
+      assert_nil game.ball.last_kick
+
+      position = Position.new(100, 100)
+      game.ball.position = position
+      game.ball.velocity = Velocity.new(0, 0)
+      player.position = position
+
+      player.kick(game.ball, Position.new(300, 300))
+
+      assert_equal player.name, game.ball.last_kick[:name]
+      assert_equal player.side, game.ball.last_kick[:side]
+    end
+
     private
 
     attr_reader :game, :player

--- a/test/recorder_test.rb
+++ b/test/recorder_test.rb
@@ -108,6 +108,20 @@ module Rubygoal
       assert_in_delta 115, frames.last[:time], 0.001
     end
 
+    def test_recorded_frame_with_last_kick
+      Rubygoal.configuration.record_last_kick = true
+      name, player = @game.team_home.players.first
+      player.position = @game.ball.position
+      player.kick(@game.ball, Position.new(100, 100))
+      @game.update
+
+      last_frame = recorder.to_hash[:frames].last
+
+      assert !last_frame[:last_kick].nil?
+      assert_equal name, last_frame[:last_kick][0]
+      assert_equal :home, last_frame[:last_kick][1]
+    end
+
     private
 
     attr_reader :game, :recorder


### PR DESCRIPTION
- Every time the ball is kicked, the player's name and side are registered in the ball. This value is `nil` when the game starts and after each goal.
- When the game frames are generated, a `last_kick` field is inserted at the end of the frame with the previous information if the option `record_last_kick` is set to `true`.
- Some tests have been added to check if the kick is being registered in the ball and the game frames.